### PR TITLE
Updated project tree.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  ros:
+    build: ./ros/
+
+  gazebo:
+    build: ./simulator/
+  
+  # TODO: add services that correspond to a node. Each node should be run in a separate container.

--- a/ros/Dockerfile
+++ b/ros/Dockerfile
@@ -25,3 +25,7 @@ RUN apt-get install -y python3-rosmsg
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 CMD /bin/bash
+
+# Build application
+# TODO
+

--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -1,0 +1,6 @@
+FROM gazebo:gzserver8
+
+ENV TERM=xterm-256color
+
+WORKDIR ws
+


### PR DESCRIPTION
I propose we use a folder tree with two different Dockerfiles: one for ROS and one for Gazebo simulator. Each ROS node should be run in a different container (recommended) based on the ROS image. These nodes can be configured in the **docker-compose.yaml** file. 
